### PR TITLE
Remove old refs to App Center

### DIFF
--- a/docs/test/wallet-application/android.md
+++ b/docs/test/wallet-application/android.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-You can download the application at the [App Center](https://install.appcenter.ms/orgs/eu-digital-identity-wallet/apps/eudi-reference-android/distribution_groups/eudi%20wallet%20(demo)%20public){:target="_blank"}.
+You can find and download all the Demo versions of the application in the [GitHub Releases] section (https://github.com/eu-digital-identity-wallet/eudi-app-android-wallet-ui/releases){:target="_blank"}.
 
 For the proximity flow, you will also need to download the Android Verifier app. More information can be found [on the Proximity Verifier page](../proximity-verifier.md).
 


### PR DESCRIPTION
Hi,

this PR:
* removes the broken App Center link for the Android Demo  app download (see #99 for ref) and switches to GH Releases.

Let me know if you need further info, thanks!