### PR TITLE
Switch URL for coherence with ARF deploy

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,7 @@ extra:
 
 nav:
   - European Digital Identity Wallet: https://eudi.dev/latest/
-  - Architecture and reference framework: https://eudi.dev/latest/architecture-and-reference-framework-main/
+  - Architecture and reference framework: https://eudi.dev/latest/about/
   - Discussion topics: https://eudi.dev/latest/discussion-topics/
   - Technical specifications: https://eudi.dev/latest/technical-specifications/
   - Reference Implementation:


### PR DESCRIPTION
This PR changes a URL for coherence with the ARF deployment, so the navigation is the same throughout all the 3 sites.
The same applies to the FCAF repo (https://github.com/eu-digital-identity-wallet/eudi-doc-functional-conformance-assessment/pull/17) 

Thanks